### PR TITLE
upgraded erlang18 to v18.3.4.11 and build function update

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,16 +1,24 @@
 pkg_name=erlang18
 pkg_origin=core
-pkg_version=18.3
+pkg_version=18.3.4.11
 pkg_description="A programming language for massively scalable soft real-time systems."
 pkg_upstream_url="http://www.erlang.org/"
 pkg_dirname=otp_src_${pkg_version}
 pkg_license=('Apache-2.0')
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_source=http://www.erlang.org/download/otp_src_${pkg_version}.tar.gz
+pkg_source=https://api.github.com/repos/erlang/otp/tarball/refs/tags/OTP-${pkg_version}
 pkg_filename=otp_src_${pkg_version}.tar.gz
-pkg_shasum=fdab8129a1cb935db09f1832e3a7d511a4aeb2b9bb3602ca6a7ccb9730d5c9c3
+pkg_shasum=6f710780ff83e672aee9e6dc5739853897dc0b36a52660d67a6997fe5a849c80
 pkg_deps=(core/glibc core/zlib core/ncurses core/openssl core/sed)
-pkg_build_deps=(core/coreutils core/gcc core/make core/openssl core/perl core/m4)
+pkg_build_deps=(
+	core/coreutils
+       	core/gcc
+       	core/make
+       	core/openssl
+       	core/perl
+       	core/m4
+	core/autoconf/2.69
+)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
@@ -26,20 +34,23 @@ do_prepare() {
     ln -sv "$(pkg_path_for coreutils)/bin/rm" /bin/rm
     _clean_rm=true
   fi
+	cp -r ${HAB_CACHE_SRC_PATH}/erlang-otp-0b88ef5/* ${HAB_CACHE_SRC_PATH}/${pkg_dirname}
 }
 
 do_build() {
-  ./configure --prefix="${pkg_prefix}" \
-              --enable-threads \
-              --enable-smp-support \
-              --enable-kernel-poll \
-              --enable-dynamic-ssl-lib \
-              --enable-shared-zlib \
-              --enable-hipe \
-              --with-ssl="$(pkg_path_for openssl)/lib" \
-              --with-ssl-include="$(pkg_path_for openssl)/include" \
-              --without-javac
-  make
+	./otp_build autoconf
+	./otp_build configure \
+		--prefix="${pkg_prefix}" \
+		--enable-threads \
+		--enable-smp-support \
+		--enable-kernel-poll \
+		--enable-dynamic-ssl-lib \
+		--enable-shared-zlib \
+		--enable-hipe \
+		--with-ssl="$(pkg_path_for openssl)" \
+		--with-ssl-include="$(pkg_path_for openssl)/include" \
+		--without-javac
+	make
 }
 
 do_end() {

--- a/plan.sh
+++ b/plan.sh
@@ -23,6 +23,11 @@ pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
 pkg_lib_dirs=(lib)
 
+do_unpack() {
+	cd ${HAB_CACHE_SRC_PATH}
+	tar zxf otp_src_${pkg_version}.tar.gz --one-top-level=${pkg_dirname} --strip-components=1
+}
+
 do_prepare() {
   # The `/bin/pwd` path is hardcoded, so we'll add a symlink if needed.
   if [[ ! -r /bin/pwd ]]; then
@@ -34,7 +39,11 @@ do_prepare() {
     ln -sv "$(pkg_path_for coreutils)/bin/rm" /bin/rm
     _clean_rm=true
   fi
-	cp -r ${HAB_CACHE_SRC_PATH}/erlang-otp-0b88ef5/* ${HAB_CACHE_SRC_PATH}/${pkg_dirname}
+	# The `/usr/bin/env` path is hardcoded, so we'll add a symlink if needed.
+	if [[ ! -r /usr/bin/env ]]; then
+		ln -sv "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
+		_clean_env=true
+	fi
 }
 
 do_build() {
@@ -62,4 +71,8 @@ do_end() {
   if [[ -n "$_clean_rm" ]]; then
     rm -fv /bin/rm
   fi
+
+	if [[ -n "$_clean_env" ]]; then
+		rm -fv /usr/bin/env
+	fi
 }


### PR DESCRIPTION
1. upgraded erlang18 to v18.3.4.11
2. updated build function as per change in source tarball
3. using step down autoconf v2.69 due to incompatibility with autoconf v2.71

Signed-off-by: Nimit <nimit.jyotiana@hotmail.com>